### PR TITLE
feat: implement dark mode theme

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,11 +1,16 @@
 import { CssBaseline, ThemeProvider } from "@mui/material";
+import { useMemo } from "react";
 import { Route, Routes } from "react-router-dom";
+import { ThemeModeProvider, useThemeMode } from "./contexts/ThemeModeContext";
+import Home from "./pages/Home";
 import Login from "./pages/Login";
 import Register from "./pages/Register";
-import Home from "./pages/Home";
-import theme from "./utils/theme";
+import { createAppTheme } from "./utils/theme";
 
-function App() {
+function ThemedApp() {
+	const { mode } = useThemeMode();
+	const theme = useMemo(() => createAppTheme(mode), [mode]);
+
 	return (
 		<ThemeProvider theme={theme}>
 			<CssBaseline />
@@ -15,6 +20,14 @@ function App() {
 				<Route path="/register" element={<Register />} />
 			</Routes>
 		</ThemeProvider>
+	);
+}
+
+function App() {
+	return (
+		<ThemeModeProvider>
+			<ThemedApp />
+		</ThemeModeProvider>
 	);
 }
 

--- a/frontend/src/components/AuthLayout/index.tsx
+++ b/frontend/src/components/AuthLayout/index.tsx
@@ -5,6 +5,7 @@ import { alpha, useTheme } from "@mui/material/styles";
 import type { ReactNode } from "react";
 import { useNavigate } from "react-router-dom";
 import logoSm from "../../assets/logo-sm.png";
+import ThemeToggle from "../ThemeToggle";
 
 interface AuthLayoutProps {
   children: ReactNode;
@@ -93,8 +94,10 @@ export default function AuthLayout({ children }: AuthLayoutProps) {
           }}
         />
 
-        {/* Coluna direita — simetria */}
-        <Box sx={{ flex: 1 }} />
+        {/* Coluna direita — toggle de tema */}
+        <Box sx={{ flex: 1, display: "flex", justifyContent: "flex-end" }}>
+          <ThemeToggle size="small" />
+        </Box>
       </Box>
 
       {/* Card */}

--- a/frontend/src/components/Navbar/index.tsx
+++ b/frontend/src/components/Navbar/index.tsx
@@ -13,6 +13,7 @@ import { useState } from "react";
 import { useNavigate } from "react-router-dom";
 import { useScrollY } from "../../hooks/useScrollY";
 import logoSm from "../../assets/logo-sm.png";
+import ThemeToggle from "../ThemeToggle";
 
 const NAV_ITEMS = [
   { label: "Início", id: "inicio" },
@@ -51,7 +52,7 @@ export default function Navbar() {
         position="sticky"
         sx={{
           top: 0,
-          bgcolor: alpha("#FFFFFF", progress * 0.88),
+          bgcolor: alpha(theme.palette.background.paper, progress * 0.88),
           backdropFilter: `blur(${progress * 14}px)`,
           borderBottom: `1px solid ${alpha(theme.palette.brand.main, progress * 0.1)}`,
           transition: "background-color 0.3s ease, border-color 0.3s ease",
@@ -126,6 +127,7 @@ export default function Navbar() {
               alignItems: "center",
             }}
           >
+            <ThemeToggle size="small" />
             <Button
               onClick={() => navigate("/login")}
               sx={{
@@ -173,16 +175,22 @@ export default function Navbar() {
             </Button>
           </Box>
 
-          {/* Ícone hambúrguer — mobile */}
-          <IconButton
-            onClick={() => setDrawerOpen(true)}
+          {/* Ações — mobile */}
+          <Box
             sx={{
               display: { xs: "flex", md: "none" },
-              color: theme.palette.brand.main,
+              alignItems: "center",
+              gap: 1,
             }}
           >
-            <MenuIcon />
-          </IconButton>
+            <ThemeToggle size="small" />
+            <IconButton
+              onClick={() => setDrawerOpen(true)}
+              sx={{ color: theme.palette.brand.main }}
+            >
+              <MenuIcon />
+            </IconButton>
+          </Box>
         </Toolbar>
       </AppBar>
 

--- a/frontend/src/components/ThemeToggle/index.tsx
+++ b/frontend/src/components/ThemeToggle/index.tsx
@@ -1,0 +1,44 @@
+import DarkModeOutlinedIcon from "@mui/icons-material/DarkModeOutlined";
+import LightModeOutlinedIcon from "@mui/icons-material/LightModeOutlined";
+import IconButton from "@mui/material/IconButton";
+import Tooltip from "@mui/material/Tooltip";
+import { alpha, useTheme } from "@mui/material/styles";
+import { useThemeMode } from "../../contexts/ThemeModeContext";
+
+interface ThemeToggleProps {
+	size?: "small" | "medium";
+}
+
+export default function ThemeToggle({ size = "medium" }: ThemeToggleProps) {
+	const theme = useTheme();
+	const { mode, toggleMode } = useThemeMode();
+	const isDark = mode === "dark";
+	const label = isDark ? "Ativar modo claro" : "Ativar modo escuro";
+
+	return (
+		<Tooltip title={label} arrow>
+			<IconButton
+				onClick={toggleMode}
+				aria-label={label}
+				size={size}
+				sx={{
+					color: theme.palette.brand.main,
+					bgcolor: alpha(theme.palette.brand.main, 0.08),
+					borderRadius: "12px",
+					p: size === "small" ? 0.75 : 1,
+					transition: "background-color 0.2s ease, transform 0.2s ease",
+					"&:hover": {
+						bgcolor: alpha(theme.palette.brand.main, 0.16),
+						transform: "translateY(-1px)",
+					},
+				}}
+			>
+				{isDark ? (
+					<LightModeOutlinedIcon sx={{ fontSize: "1.15rem" }} />
+				) : (
+					<DarkModeOutlinedIcon sx={{ fontSize: "1.15rem" }} />
+				)}
+			</IconButton>
+		</Tooltip>
+	);
+}

--- a/frontend/src/contexts/ThemeModeContext.tsx
+++ b/frontend/src/contexts/ThemeModeContext.tsx
@@ -1,0 +1,52 @@
+import type { PaletteMode } from "@mui/material";
+import {
+	createContext,
+	useCallback,
+	useContext,
+	useEffect,
+	useMemo,
+	useState,
+	type ReactNode,
+} from "react";
+
+interface ThemeModeContextValue {
+	mode: PaletteMode;
+	toggleMode: () => void;
+}
+
+const STORAGE_KEY = "nutrihub:theme-mode";
+
+const ThemeModeContext = createContext<ThemeModeContextValue | undefined>(undefined);
+
+function getInitialMode(): PaletteMode {
+	if (typeof window === "undefined") return "light";
+	const stored = window.localStorage.getItem(STORAGE_KEY);
+	if (stored === "light" || stored === "dark") return stored;
+	return window.matchMedia("(prefers-color-scheme: dark)").matches ? "dark" : "light";
+}
+
+interface ThemeModeProviderProps {
+	children: ReactNode;
+}
+
+export function ThemeModeProvider({ children }: ThemeModeProviderProps) {
+	const [mode, setMode] = useState<PaletteMode>(getInitialMode);
+
+	useEffect(() => {
+		window.localStorage.setItem(STORAGE_KEY, mode);
+	}, [mode]);
+
+	const toggleMode = useCallback(() => {
+		setMode((current) => (current === "light" ? "dark" : "light"));
+	}, []);
+
+	const value = useMemo(() => ({ mode, toggleMode }), [mode, toggleMode]);
+
+	return <ThemeModeContext.Provider value={value}>{children}</ThemeModeContext.Provider>;
+}
+
+export function useThemeMode() {
+	const ctx = useContext(ThemeModeContext);
+	if (!ctx) throw new Error("useThemeMode deve ser usado dentro de ThemeModeProvider");
+	return ctx;
+}

--- a/frontend/src/utils/theme.ts
+++ b/frontend/src/utils/theme.ts
@@ -1,4 +1,4 @@
-import { createTheme } from "@mui/material/styles";
+import { createTheme, type PaletteMode, type PaletteOptions } from "@mui/material/styles";
 
 declare module "@mui/material/styles" {
 	interface Palette {
@@ -43,85 +43,139 @@ declare module "@mui/material/styles" {
 	}
 }
 
-const theme = createTheme({
-	palette: {
-		primary: {
-			main: "#2E7D4F",
-			light: "#4CAF74",
-			dark: "#458C63",
-		},
-		background: {
-			default: "#F2F4F3",
-			paper: "#FFFFFF",
-		},
-		brand: {
-			main: "#2E7D4F",
-			mainAlt: "#458C63",
-			selectedItem: "#54946F",
-			hoverItem: "#438A61",
-			greenCircleBg: "#35955B",
-			highlight: "#4CAF74",
-		},
-		green: {
-			buttonBg: "#629E7B",
-			altSelectedItem: "#589772",
-			roundButtonBg: "#4D9069",
-			cardTitle: "#6B7A72",
-			altCardTitle: "#ABC497",
-			text3: "#88B59B",
-		},
-		neutral: {
-			background: "#F2F4F3",
-			card: "#FFFFFF",
-			textFieldBg: "#F5F5F5",
-			altTempBackground: "#E8F5ED",
-			selectedGender: "#E5F2EA",
-		},
-		typography: {
-			mainText: "#111714",
-			secondaryText: "#7E7A72",
-			secondaryCardText: "#A8B5AE",
-			altSecondaryText: "#B2B5B8",
-			secondaryAltText: "#A1BFA2",
-			mobileAlt: "#BFD1B6",
-			macroSecondary: "#947A72",
-		},
-		text: {
-			primary: "#111714",
-			secondary: "#7E7A72",
-		},
+const lightPalette: PaletteOptions = {
+	mode: "light",
+	primary: {
+		main: "#2E7D4F",
+		light: "#4CAF74",
+		dark: "#458C63",
+	},
+	background: {
+		default: "#F2F4F3",
+		paper: "#FFFFFF",
+	},
+	brand: {
+		main: "#2E7D4F",
+		mainAlt: "#458C63",
+		selectedItem: "#54946F",
+		hoverItem: "#438A61",
+		greenCircleBg: "#35955B",
+		highlight: "#4CAF74",
+	},
+	green: {
+		buttonBg: "#629E7B",
+		altSelectedItem: "#589772",
+		roundButtonBg: "#4D9069",
+		cardTitle: "#6B7A72",
+		altCardTitle: "#ABC497",
+		text3: "#88B59B",
+	},
+	neutral: {
+		background: "#F2F4F3",
+		card: "#FFFFFF",
+		textFieldBg: "#F5F5F5",
+		altTempBackground: "#E8F5ED",
+		selectedGender: "#E5F2EA",
 	},
 	typography: {
-		fontFamily: '"DM Sans", sans-serif',
-		fontWeightLight: 300,
-		fontWeightRegular: 400,
-		fontWeightMedium: 500,
-		fontWeightBold: 700,
-		button: {
-			fontFamily: '"Inter", sans-serif',
-			fontWeight: 600,
+		mainText: "#111714",
+		secondaryText: "#7E7A72",
+		secondaryCardText: "#A8B5AE",
+		altSecondaryText: "#B2B5B8",
+		secondaryAltText: "#A1BFA2",
+		mobileAlt: "#BFD1B6",
+		macroSecondary: "#947A72",
+	},
+	text: {
+		primary: "#111714",
+		secondary: "#7E7A72",
+	},
+};
+
+const darkPalette: PaletteOptions = {
+	mode: "dark",
+	primary: {
+		main: "#4CAF74",
+		light: "#6DC390",
+		dark: "#35955B",
+	},
+	background: {
+		default: "#0F1412",
+		paper: "#1A211D",
+	},
+	brand: {
+		main: "#4CAF74",
+		mainAlt: "#5CB884",
+		selectedItem: "#3D8A5F",
+		hoverItem: "#5CB884",
+		greenCircleBg: "#35955B",
+		highlight: "#6DC390",
+	},
+	green: {
+		buttonBg: "#629E7B",
+		altSelectedItem: "#589772",
+		roundButtonBg: "#4D9069",
+		cardTitle: "#AAB8B0",
+		altCardTitle: "#7D9C6A",
+		text3: "#88B59B",
+	},
+	neutral: {
+		background: "#0F1412",
+		card: "#1A211D",
+		textFieldBg: "#242B27",
+		altTempBackground: "#1F2E25",
+		selectedGender: "#1C2620",
+	},
+	typography: {
+		mainText: "#F2F4F3",
+		secondaryText: "#9FA8A3",
+		secondaryCardText: "#6E7A73",
+		altSecondaryText: "#78807F",
+		secondaryAltText: "#89A68A",
+		mobileAlt: "#7A8E73",
+		macroSecondary: "#B89F94",
+	},
+	text: {
+		primary: "#F2F4F3",
+		secondary: "#9FA8A3",
+	},
+};
+
+export function createAppTheme(mode: PaletteMode) {
+	return createTheme({
+		palette: mode === "dark" ? darkPalette : lightPalette,
+		typography: {
+			fontFamily: '"DM Sans", sans-serif',
+			fontWeightLight: 300,
+			fontWeightRegular: 400,
+			fontWeightMedium: 500,
+			fontWeightBold: 700,
+			button: {
+				fontFamily: '"Inter", sans-serif',
+				fontWeight: 600,
+			},
 		},
-	},
-	shape: {
-		borderRadius: 12,
-	},
-	components: {
-		MuiButton: {
-			styleOverrides: {
-				root: {
-					textTransform: "none",
-					boxShadow: "none",
-					fontFamily: '"Inter", sans-serif',
-					"&:hover": { boxShadow: "none" },
+		shape: {
+			borderRadius: 12,
+		},
+		components: {
+			MuiButton: {
+				styleOverrides: {
+					root: {
+						textTransform: "none",
+						boxShadow: "none",
+						fontFamily: '"Inter", sans-serif',
+						"&:hover": { boxShadow: "none" },
+					},
+				},
+			},
+			MuiAppBar: {
+				styleOverrides: {
+					root: { boxShadow: "none" },
 				},
 			},
 		},
-		MuiAppBar: {
-			styleOverrides: {
-				root: { boxShadow: "none" },
-			},
-		},
-	},
-});
+	});
+}
 
-export default theme;
+export default createAppTheme("light");


### PR DESCRIPTION
# Dark mode
Adiciona suporte a dark mode em todas as telas, com toggle para alternar entre os modos.

## O que foi feito
- Tema refatorado como factory createAppTheme(mode) em [frontend/src/utils/theme.ts](https://github.com/devBrait/nutri-hub-app/blob/feat/dark-mode/frontend/src/utils/theme.ts), com paletas light e dark.
- Novo [ThemeModeContext](https://github.com/devBrait/nutri-hub-app/blob/feat/dark-mode/frontend/src/contexts/ThemeModeContext.tsx) gerencia o modo, persiste em localStorage e respeita prefers-color-scheme.
- Novo componente [ThemeToggle](https://github.com/devBrait/nutri-hub-app/blob/feat/dark-mode/frontend/src/components/ThemeToggle/index.tsx) integrado à [Navbar](https://github.com/devBrait/nutri-hub-app/blob/feat/dark-mode/frontend/src/components/Navbar/index.tsx) (desktop + mobile) e ao [AuthLayout](https://github.com/devBrait/nutri-hub-app/blob/feat/dark-mode/frontend/src/components/AuthLayout/index.tsx).
- [App.tsx](https://github.com/devBrait/nutri-hub-app/blob/feat/dark-mode/frontend/src/App.tsx) envolvido no provider e recalcula o tema via useMemo.

Demais telas já usavam theme.palette.*, então adaptaram automaticamente.