### PR TITLE
Add Render deployment configuration for auth, patient, and clinic services

### DIFF
--- a/render.yaml
+++ b/render.yaml
@@ -1,0 +1,54 @@
+services:
+
+  - type: web
+    name: nutrihub-auth
+    runtime: docker
+    dockerfilePath: ./backend/NutriHubAuth/Dockerfile
+    dockerContext: ./backend/NutriHubAuth
+    branch: main
+    plan: free
+    envVars:
+      - key: ASPNETCORE_ENVIRONMENT
+        value: Production
+      - key: ASPNETCORE_HTTP_PORTS
+        value: "10000"
+      - key: ConnectionStrings__DefaultConnection
+        sync: false
+      - key: Jwt__Secret
+        sync: false
+      - key: Jwt__Issuer
+        value: NutriHubAuth
+      - key: Jwt__Audience
+        value: NutriHub
+      - key: Jwt__ExpiresInMinutes
+        value: "60"
+
+  - type: web
+    name: nutrihub-patient
+    runtime: docker
+    dockerfilePath: ./backend/NutriHubPatient/Dockerfile
+    dockerContext: ./backend/NutriHubPatient
+    branch: main
+    plan: free
+    envVars:
+      - key: ASPNETCORE_ENVIRONMENT
+        value: Production
+      - key: ASPNETCORE_HTTP_PORTS
+        value: "10000"
+      - key: ConnectionStrings__DefaultConnection
+        sync: false
+
+  - type: web
+    name: nutrihub-clinic
+    runtime: docker
+    dockerfilePath: ./backend/NutriHubClinic/Dockerfile
+    dockerContext: ./backend/NutriHubClinic
+    branch: main
+    plan: free
+    envVars:
+      - key: ASPNETCORE_ENVIRONMENT
+        value: Production
+      - key: ASPNETCORE_HTTP_PORTS
+        value: "10000"
+      - key: ConnectionStrings__DefaultConnection
+        sync: false


### PR DESCRIPTION
This pull request introduces a new `render.yaml` configuration file to define deployment settings for the project’s backend services. The file sets up three separate web services, each with Docker-based deployment, environment variables, and branch targeting for production deployment.

Deployment configuration:

* Added a `render.yaml` file to configure three web services: `nutrihub-auth`, `nutrihub-patient`, and `nutrihub-clinic`, each with its own Dockerfile, context, and environment variables for production deployment.