### PR TITLE
Standardize messages, return token on registration, and improve toasts

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -9,7 +9,13 @@
       "Bash(dotnet add *)",
       "Bash(dotnet build *)",
       "Bash(dotnet ef *)",
-      "Bash(dotnet test *)"
+      "Bash(dotnet test *)",
+      "Bash(Get-ChildItem -Path \"C:\\\\Users\\\\lorim\\\\Documents\\\\Projects\\\\nutri-hub\" -Recurse -Directory)",
+      "Bash(Select-Object -First 20 FullName)",
+      "Bash(Get-ChildItem -Path \"C:\\\\Users\\\\lorim\\\\Documents\\\\Projects\\\\nutri-hub\" -Directory)",
+      "Bash(Select-Object Name)",
+      "PowerShell(head *)",
+      "Bash(npx tsc *)"
     ]
   }
 }

--- a/backend/NutriHubAuth/src/NutriHubAuth.API/Common/ErrorCodes.cs
+++ b/backend/NutriHubAuth/src/NutriHubAuth.API/Common/ErrorCodes.cs
@@ -1,0 +1,18 @@
+namespace NutriHubAuth.API.Common
+{
+    public static class ErrorCodes
+    {
+        public const string NameRequired = "NAME_REQUIRED";
+        public const string NameInvalidLength = "NAME_INVALID_LENGTH";
+        public const string EmailRequired = "EMAIL_REQUIRED";
+        public const string EmailInvalidFormat = "EMAIL_INVALID_FORMAT";
+        public const string PasswordRequired = "PASSWORD_REQUIRED";
+        public const string PasswordTooShort = "PASSWORD_TOO_SHORT";
+        public const string PasswordMissingUppercase = "PASSWORD_MISSING_UPPERCASE";
+        public const string PasswordMissingLowercase = "PASSWORD_MISSING_LOWERCASE";
+        public const string PasswordMissingNumber = "PASSWORD_MISSING_NUMBER";
+        public const string RoleInvalid = "ROLE_INVALID";
+        public const string EmailAlreadyRegistered = "EMAIL_ALREADY_REGISTERED";
+        public const string InvalidCredentials = "INVALID_CREDENTIALS";
+    }
+}

--- a/backend/NutriHubAuth/src/NutriHubAuth.API/Models/Requests/AuthRequest.cs
+++ b/backend/NutriHubAuth/src/NutriHubAuth.API/Models/Requests/AuthRequest.cs
@@ -1,4 +1,3 @@
-using System.Text.Json.Serialization;
 using NutriHubAuth.API.Models.Enums;
 
 namespace NutriHubAuth.API.Models.Requests
@@ -8,7 +7,6 @@ namespace NutriHubAuth.API.Models.Requests
         public string Name { get; set; } = string.Empty;
         public string Email { get; set; } = string.Empty;
         public string Password { get; set; } = string.Empty;
-        [JsonConverter(typeof(JsonStringEnumConverter))]
         public UserRoles Role { get; set; }
     }
 }

--- a/backend/NutriHubAuth/src/NutriHubAuth.API/Models/Responses/AuthResponse.cs
+++ b/backend/NutriHubAuth/src/NutriHubAuth.API/Models/Responses/AuthResponse.cs
@@ -5,7 +5,10 @@ namespace NutriHubAuth.API.Models.Responses
     public class AuthResponse
     {
         public bool Success { get; set; }
+        public string? AccessToken { get; set; }
+        public string? RefreshToken { get; set; }
         public Guid? UserId { get; set; }
+        public string? Name { get; set; }
         public UserRoles? Role { get; set; }
         public string? Message { get; set; }
         public IEnumerable<string> Errors { get; set; } = [];

--- a/backend/NutriHubAuth/src/NutriHubAuth.API/Program.cs
+++ b/backend/NutriHubAuth/src/NutriHubAuth.API/Program.cs
@@ -15,10 +15,13 @@ using NutriHubAuth.API.UseCases.Register;
 using NutriHubAuth.API.Validators;
 using Scalar.AspNetCore;
 using System.Text;
+using System.Text.Json.Serialization;
 
 var builder = WebApplication.CreateBuilder(args);
 
-builder.Services.AddControllers();
+builder.Services.AddControllers()
+    .AddJsonOptions(options =>
+        options.JsonSerializerOptions.Converters.Add(new JsonStringEnumConverter()));
 builder.Services.AddOpenApi(options =>
 {
     options.AddDocumentTransformer<BearerSecuritySchemeTransformer>();

--- a/backend/NutriHubAuth/src/NutriHubAuth.API/UseCases/Login/LoginUseCase.cs
+++ b/backend/NutriHubAuth/src/NutriHubAuth.API/UseCases/Login/LoginUseCase.cs
@@ -1,4 +1,5 @@
 using FluentValidation;
+using NutriHubAuth.API.Common;
 using NutriHubAuth.API.Models;
 using NutriHubAuth.API.Models.Requests;
 using NutriHubAuth.API.Models.Responses;
@@ -43,7 +44,7 @@ namespace NutriHubAuth.API.UseCases.Login
                     return new LoginResponse
                     {
                         Success = false,
-                        Errors = ["Invalid email or password."]
+                        Errors = [ErrorCodes.InvalidCredentials]
                     };
 
                 var accessToken = _tokenService.GenerateAccessToken(user);

--- a/backend/NutriHubAuth/src/NutriHubAuth.API/UseCases/Register/RegisterUseCase.cs
+++ b/backend/NutriHubAuth/src/NutriHubAuth.API/UseCases/Register/RegisterUseCase.cs
@@ -1,19 +1,29 @@
 using FluentValidation;
+using NutriHubAuth.API.Common;
 using NutriHubAuth.API.Models;
 using NutriHubAuth.API.Models.Requests;
 using NutriHubAuth.API.Models.Responses;
 using NutriHubAuth.API.Repositories;
+using NutriHubAuth.API.Services;
 
 namespace NutriHubAuth.API.UseCases.Register
 {
     public class RegisterUseCase : IRegisterUseCase<AuthRequest, AuthResponse>
     {
         private readonly IUserRepository _userRepository;
+        private readonly IRefreshTokenRepository _refreshTokenRepository;
+        private readonly ITokenService _tokenService;
         private readonly IValidator<AuthRequest> _validator;
 
-        public RegisterUseCase(IUserRepository userRepository, IValidator<AuthRequest> validator)
+        public RegisterUseCase(
+            IUserRepository userRepository,
+            IRefreshTokenRepository refreshTokenRepository,
+            ITokenService tokenService,
+            IValidator<AuthRequest> validator)
         {
             _userRepository = userRepository;
+            _refreshTokenRepository = refreshTokenRepository;
+            _tokenService = tokenService;
             _validator = validator;
         }
 
@@ -34,7 +44,7 @@ namespace NutriHubAuth.API.UseCases.Register
                     return new AuthResponse
                     {
                         Success = false,
-                        Errors = ["Email already registered."]
+                        Errors = [ErrorCodes.EmailAlreadyRegistered]
                     };
 
                 var passwordHash = BCrypt.Net.BCrypt.HashPassword(request.Password);
@@ -42,10 +52,19 @@ namespace NutriHubAuth.API.UseCases.Register
 
                 await _userRepository.SaveAsync(user);
 
+                var accessToken = _tokenService.GenerateAccessToken(user);
+                var refreshTokenValue = _tokenService.GenerateRefreshToken();
+                var refreshToken = new RefreshToken(user.Id, refreshTokenValue, DateTime.UtcNow.AddDays(7));
+
+                await _refreshTokenRepository.SaveAsync(refreshToken);
+
                 return new AuthResponse
                 {
                     Success = true,
+                    AccessToken = accessToken,
+                    RefreshToken = refreshTokenValue,
                     UserId = user.Id,
+                    Name = user.Name,
                     Role = user.Role,
                     Message = "User registered successfully."
                 };

--- a/backend/NutriHubAuth/src/NutriHubAuth.API/Validators/AuthRequestValidator.cs
+++ b/backend/NutriHubAuth/src/NutriHubAuth.API/Validators/AuthRequestValidator.cs
@@ -1,4 +1,5 @@
 using FluentValidation;
+using NutriHubAuth.API.Common;
 using NutriHubAuth.API.Models.Requests;
 
 namespace NutriHubAuth.API.Validators
@@ -8,22 +9,22 @@ namespace NutriHubAuth.API.Validators
         public AuthRequestValidator()
         {
             RuleFor(x => x.Name)
-                .NotEmpty().WithMessage("Name is required.")
-                .Length(2, 100).WithMessage("Name must be between 2 and 100 characters.");
+                .NotEmpty().WithMessage(ErrorCodes.NameRequired)
+                .Length(2, 100).WithMessage(ErrorCodes.NameInvalidLength);
 
             RuleFor(x => x.Email)
-                .NotEmpty().WithMessage("Email is required.")
-                .EmailAddress().WithMessage("Invalid email format.");
+                .NotEmpty().WithMessage(ErrorCodes.EmailRequired)
+                .EmailAddress().WithMessage(ErrorCodes.EmailInvalidFormat);
 
             RuleFor(x => x.Password)
-                .NotEmpty().WithMessage("Password is required.")
-                .MinimumLength(8).WithMessage("Password must be at least 8 characters.")
-                .Matches(@"[A-Z]").WithMessage("Password must contain at least one uppercase letter.")
-                .Matches(@"[a-z]").WithMessage("Password must contain at least one lowercase letter.")
-                .Matches(@"\d").WithMessage("Password must contain at least one number.");
+                .NotEmpty().WithMessage(ErrorCodes.PasswordRequired)
+                .MinimumLength(8).WithMessage(ErrorCodes.PasswordTooShort)
+                .Matches(@"[A-Z]").WithMessage(ErrorCodes.PasswordMissingUppercase)
+                .Matches(@"[a-z]").WithMessage(ErrorCodes.PasswordMissingLowercase)
+                .Matches(@"\d").WithMessage(ErrorCodes.PasswordMissingNumber);
 
             RuleFor(x => x.Role)
-                .IsInEnum().WithMessage("Invalid role.");
+                .IsInEnum().WithMessage(ErrorCodes.RoleInvalid);
         }
     }
 }

--- a/backend/NutriHubAuth/src/NutriHubAuth.API/Validators/LoginRequestValidator.cs
+++ b/backend/NutriHubAuth/src/NutriHubAuth.API/Validators/LoginRequestValidator.cs
@@ -1,4 +1,5 @@
 using FluentValidation;
+using NutriHubAuth.API.Common;
 using NutriHubAuth.API.Models.Requests;
 
 namespace NutriHubAuth.API.Validators
@@ -8,11 +9,11 @@ namespace NutriHubAuth.API.Validators
         public LoginRequestValidator()
         {
             RuleFor(x => x.Email)
-                .NotEmpty().WithMessage("Email is required.")
-                .EmailAddress().WithMessage("Invalid email format.");
+                .NotEmpty().WithMessage(ErrorCodes.EmailRequired)
+                .EmailAddress().WithMessage(ErrorCodes.EmailInvalidFormat);
 
             RuleFor(x => x.Password)
-                .NotEmpty().WithMessage("Password is required.");
+                .NotEmpty().WithMessage(ErrorCodes.PasswordRequired);
         }
     }
 }

--- a/backend/NutriHubAuth/tests/NutriHubAuth.Tests/UseCases/AuthUseCaseTests.cs
+++ b/backend/NutriHubAuth/tests/NutriHubAuth.Tests/UseCases/AuthUseCaseTests.cs
@@ -1,8 +1,10 @@
 using Moq;
+using NutriHubAuth.API.Common;
 using NutriHubAuth.API.Models;
 using NutriHubAuth.API.Models.Enums;
 using NutriHubAuth.API.Models.Requests;
 using NutriHubAuth.API.Repositories;
+using NutriHubAuth.API.Services;
 using NutriHubAuth.API.UseCases.Register;
 using NutriHubAuth.API.Validators;
 
@@ -10,6 +12,16 @@ namespace NutriHubAuth.Tests.UseCases;
 
 public class AuthUseCaseTests
 {
+    private static RegisterUseCase CreateUseCase(
+        Mock<IUserRepository> userRepo,
+        Mock<IRefreshTokenRepository>? refreshTokenRepo = null,
+        Mock<ITokenService>? tokenService = null)
+    {
+        refreshTokenRepo ??= new Mock<IRefreshTokenRepository>();
+        tokenService ??= new Mock<ITokenService>();
+        return new RegisterUseCase(userRepo.Object, refreshTokenRepo.Object, tokenService.Object, new AuthRequestValidator());
+    }
+
     [Theory]
     [InlineData("existing@user.com")]
     [InlineData("EXISTING@USER.COM")]
@@ -19,7 +31,7 @@ public class AuthUseCaseTests
         var userRepo = new Mock<IUserRepository>();
         userRepo.Setup(r => r.FindByEmailAsync(It.IsAny<string>())).ReturnsAsync(existingUser);
 
-        var useCase = new RegisterUseCase(userRepo.Object, new AuthRequestValidator());
+        var useCase = CreateUseCase(userRepo);
         var request = new AuthRequest
         {
             Name = "Another User",
@@ -31,11 +43,11 @@ public class AuthUseCaseTests
         var response = await useCase.ExecuteAsync(request);
 
         Assert.False(response.Success);
-        Assert.Contains("Email already registered.", response.Errors);
+        Assert.Contains(ErrorCodes.EmailAlreadyRegistered, response.Errors);
     }
 
     [Fact]
-    public async Task ExecuteAsync_ShouldSaveUserAndReturnSuccess_WhenRequestIsValid()
+    public async Task ExecuteAsync_ShouldSaveUserAndReturnTokens_WhenRequestIsValid()
     {
         User? savedUser = null;
         var userRepo = new Mock<IUserRepository>();
@@ -44,7 +56,14 @@ public class AuthUseCaseTests
             .Callback<User>(u => savedUser = u)
             .Returns(Task.CompletedTask);
 
-        var useCase = new RegisterUseCase(userRepo.Object, new AuthRequestValidator());
+        var refreshTokenRepo = new Mock<IRefreshTokenRepository>();
+        refreshTokenRepo.Setup(r => r.SaveAsync(It.IsAny<RefreshToken>())).Returns(Task.CompletedTask);
+
+        var tokenService = new Mock<ITokenService>();
+        tokenService.Setup(t => t.GenerateAccessToken(It.IsAny<User>())).Returns("access-token");
+        tokenService.Setup(t => t.GenerateRefreshToken()).Returns("refresh-token");
+
+        var useCase = CreateUseCase(userRepo, refreshTokenRepo, tokenService);
         var request = new AuthRequest
         {
             Name = "New User",
@@ -57,6 +76,8 @@ public class AuthUseCaseTests
 
         Assert.True(response.Success);
         Assert.Equal("User registered successfully.", response.Message);
+        Assert.Equal("access-token", response.AccessToken);
+        Assert.Equal("refresh-token", response.RefreshToken);
         Assert.NotNull(savedUser);
         Assert.Equal("new@user.com", savedUser.Email);
     }

--- a/backend/NutriHubAuth/tests/NutriHubAuth.Tests/UseCases/LoginUseCaseTests.cs
+++ b/backend/NutriHubAuth/tests/NutriHubAuth.Tests/UseCases/LoginUseCaseTests.cs
@@ -1,4 +1,5 @@
 using Moq;
+using NutriHubAuth.API.Common;
 using NutriHubAuth.API.Models;
 using NutriHubAuth.API.Models.Enums;
 using NutriHubAuth.API.Models.Requests;
@@ -35,7 +36,7 @@ public class LoginUseCaseTests
         var response = await useCase.ExecuteAsync(new LoginRequest { Email = "", Password = "StrongPass1" });
 
         Assert.False(response.Success);
-        Assert.Contains("Email is required.", response.Errors);
+        Assert.Contains(ErrorCodes.EmailRequired, response.Errors);
     }
 
     [Fact]
@@ -46,7 +47,7 @@ public class LoginUseCaseTests
         var response = await useCase.ExecuteAsync(new LoginRequest { Email = "not-an-email", Password = "StrongPass1" });
 
         Assert.False(response.Success);
-        Assert.Contains("Invalid email format.", response.Errors);
+        Assert.Contains(ErrorCodes.EmailInvalidFormat, response.Errors);
     }
 
     [Fact]
@@ -57,7 +58,7 @@ public class LoginUseCaseTests
         var response = await useCase.ExecuteAsync(new LoginRequest { Email = "user@test.com", Password = "" });
 
         Assert.False(response.Success);
-        Assert.Contains("Password is required.", response.Errors);
+        Assert.Contains(ErrorCodes.PasswordRequired, response.Errors);
     }
 
     [Fact]
@@ -70,7 +71,7 @@ public class LoginUseCaseTests
         var response = await useCase.ExecuteAsync(new LoginRequest { Email = "notfound@test.com", Password = "StrongPass1" });
 
         Assert.False(response.Success);
-        Assert.Contains("Invalid email or password.", response.Errors);
+        Assert.Contains(ErrorCodes.InvalidCredentials, response.Errors);
     }
 
     [Fact]
@@ -85,7 +86,7 @@ public class LoginUseCaseTests
         var response = await useCase.ExecuteAsync(new LoginRequest { Email = "user@test.com", Password = "WrongPass1" });
 
         Assert.False(response.Success);
-        Assert.Contains("Invalid email or password.", response.Errors);
+        Assert.Contains(ErrorCodes.InvalidCredentials, response.Errors);
     }
 
     [Fact]

--- a/backend/NutriHubAuth/tests/NutriHubAuth.Tests/Validators/LoginRequestValidatorTests.cs
+++ b/backend/NutriHubAuth/tests/NutriHubAuth.Tests/Validators/LoginRequestValidatorTests.cs
@@ -1,3 +1,4 @@
+using NutriHubAuth.API.Common;
 using NutriHubAuth.API.Models.Requests;
 using NutriHubAuth.API.Validators;
 
@@ -25,7 +26,7 @@ public class LoginRequestValidatorTests
         var result = await _validator.ValidateAsync(request);
 
         Assert.False(result.IsValid);
-        Assert.Contains(result.Errors, e => e.ErrorMessage == "Email is required.");
+        Assert.Contains(result.Errors, e => e.ErrorMessage == ErrorCodes.EmailRequired);
     }
 
     [Theory]
@@ -38,7 +39,7 @@ public class LoginRequestValidatorTests
         var result = await _validator.ValidateAsync(request);
 
         Assert.False(result.IsValid);
-        Assert.Contains(result.Errors, e => e.ErrorMessage == "Invalid email format.");
+        Assert.Contains(result.Errors, e => e.ErrorMessage == ErrorCodes.EmailInvalidFormat);
     }
 
     [Fact]
@@ -49,6 +50,6 @@ public class LoginRequestValidatorTests
         var result = await _validator.ValidateAsync(request);
 
         Assert.False(result.IsValid);
-        Assert.Contains(result.Errors, e => e.ErrorMessage == "Password is required.");
+        Assert.Contains(result.Errors, e => e.ErrorMessage == ErrorCodes.PasswordRequired);
     }
 }

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -16,37 +16,42 @@ import Register from "./pages/Register";
 import { createAppTheme } from "./utils/theme";
 
 function ThemedApp() {
-	const { mode } = useThemeMode();
-	const theme = useMemo(() => createAppTheme(mode), [mode]);
+  const { mode } = useThemeMode();
+  const theme = useMemo(() => createAppTheme(mode), [mode]);
 
-	return (
-		<ThemeProvider theme={theme}>
-			<CssBaseline />
-			<SnackbarProvider maxSnack={3} anchorOrigin={{ vertical: 'top', horizontal: 'right' }}>
-				<Routes>
-					<Route path="/" element={<Home />} />
-					<Route path="/login" element={<Login />} />
-					<Route path="/register" element={<Register />} />
-					<Route path="/onboarding" element={<Onboarding />} />
-					<Route element={<AppLayout />}>
-						<Route path="/dieta" element={<Dashboard />} />
-						<Route path="/perfil" element={<Profile />} />
-						<Route path="/refeicao" element={<EditMeal />} />
-						<Route path="/buscar-alimento" element={<FoodSearch />} />
-						<Route path="/nutricionistas" element={<Nutritionists />} />
-					</Route>
-				</Routes>
-			</SnackbarProvider>
-		</ThemeProvider>
-	);
+  return (
+    <ThemeProvider theme={theme}>
+      <CssBaseline />
+      <SnackbarProvider
+        maxSnack={3}
+        anchorOrigin={{ vertical: "bottom", horizontal: "center" }}
+        style={{ maxWidth: "min(420px, calc(100vw - 32px))" }}
+      >
+        <Routes>
+          <Route path="/" element={<Home />} />
+          <Route path="/login" element={<Login />} />
+          <Route path="/register" element={<Register />} />
+          <Route path="/onboarding" element={<Onboarding />} />
+
+          <Route element={<AppLayout />}>
+            <Route path="/diet" element={<Dashboard />} />
+            <Route path="/profile" element={<Profile />} />
+            <Route path="/meal" element={<EditMeal />} />
+            <Route path="/food-search" element={<FoodSearch />} />
+            <Route path="/nutritionists" element={<Nutritionists />} />
+          </Route>
+        </Routes>
+      </SnackbarProvider>
+    </ThemeProvider>
+  );
 }
 
 function App() {
-	return (
-		<ThemeModeProvider>
-			<ThemedApp />
-		</ThemeModeProvider>
-	);
+  return (
+    <ThemeModeProvider>
+      <ThemedApp />
+    </ThemeModeProvider>
+  );
 }
 
 export default App;

--- a/frontend/src/components/Sidebar/index.tsx
+++ b/frontend/src/components/Sidebar/index.tsx
@@ -9,6 +9,7 @@ import Typography from "@mui/material/Typography";
 import { alpha, useTheme } from "@mui/material/styles";
 import { NavLink, useNavigate } from "react-router-dom";
 import { useProfile } from "../../hooks/useProfile";
+import { logout } from "../../lib/api/auth.service";
 
 const SIDEBAR_WIDTH = 240;
 
@@ -27,6 +28,17 @@ export default function Sidebar() {
 	const theme = useTheme();
 	const navigate = useNavigate();
 	const { profile } = useProfile();
+
+	async function handleLogout() {
+		const accessToken = localStorage.getItem("accessToken") ?? "";
+		try {
+			if (accessToken) await logout(accessToken);
+		} finally {
+			localStorage.removeItem("accessToken");
+			localStorage.removeItem("refreshToken");
+			navigate("/login");
+		}
+	}
 
 	return (
 		<Box
@@ -129,7 +141,7 @@ export default function Sidebar() {
 							textTransform: "capitalize",
 						}}
 					>
-						{profile?.role === "nutritionist" ? "Nutricionista" : "Paciente"}
+						{profile?.role === "Nutritionist" ? "Nutricionista" : "Paciente"}
 					</Typography>
 				</Box>
 			</Box>
@@ -149,7 +161,7 @@ export default function Sidebar() {
 			{/* Logout */}
 			<Box sx={{ p: 1.5, borderTop: `1px solid ${alpha("#fff", 0.1)}` }}>
 				<Box
-					onClick={() => navigate("/login")}
+					onClick={handleLogout}
 					sx={navItemSx(false, theme)}
 					role="button"
 				>

--- a/frontend/src/features/auth/components/LoginForm.tsx
+++ b/frontend/src/features/auth/components/LoginForm.tsx
@@ -101,7 +101,6 @@ export default function LoginForm() {
       if (response.success) {
         localStorage.setItem("accessToken", response.accessToken ?? "");
         localStorage.setItem("refreshToken", response.refreshToken ?? "");
-        localStorage.setItem("userId", response.userId ?? "");
         navigate("/dieta");
       } else {
         response.errors.forEach(err => {

--- a/frontend/src/features/auth/components/RegisterForm.tsx
+++ b/frontend/src/features/auth/components/RegisterForm.tsx
@@ -16,12 +16,12 @@ import { useSnackbar } from "notistack";
 import { useState } from "react";
 import { useNavigate } from "react-router-dom";
 import AuthLayout from "./AuthLayout";
-import { register } from "../../../lib/api/auth.service";
+import { register, type UserRole } from "../../../lib/api/auth.service";
 import { translateError } from "../../../utils/errorTranslation";
 
-const ROLE_MAP: Record<string, number> = {
-  PACIENTE: 0,
-  NUTRICIONISTA: 1,
+const ROLE_MAP: Record<string, UserRole> = {
+  PACIENTE: "Patient",
+  NUTRICIONISTA: "Nutritionist",
 };
 
 export default function RegisterForm() {
@@ -141,6 +141,8 @@ export default function RegisterForm() {
         role: ROLE_MAP[profile],
       });
       if (response.success) {
+        localStorage.setItem("accessToken", response.accessToken ?? "");
+        localStorage.setItem("refreshToken", response.refreshToken ?? "");
         enqueueSnackbar("Conta criada com sucesso!", { variant: "success" });
         navigate("/onboarding");
       } else {

--- a/frontend/src/lib/api/auth.service.ts
+++ b/frontend/src/lib/api/auth.service.ts
@@ -1,16 +1,21 @@
 import { http } from "./httpClient";
 
+export type UserRole = "Patient" | "Nutritionist" | "Admin";
+
 export interface RegisterRequest {
 	name: string;
 	email: string;
 	password: string;
-	role: number;
+	role: UserRole;
 }
 
 export interface RegisterResponse {
 	success: boolean;
+	accessToken: string | null;
+	refreshToken: string | null;
 	userId: string | null;
-	role: number | null;
+	name: string | null;
+	role: UserRole | null;
 	message: string | null;
 	errors: string[];
 }
@@ -26,7 +31,7 @@ export interface LoginResponse {
 	refreshToken: string | null;
 	userId: string | null;
 	name: string | null;
-	role: number | null;
+	role: UserRole | null;
 	errors: string[];
 }
 
@@ -44,8 +49,9 @@ export function login(data: LoginRequest): Promise<LoginResponse> {
 	});
 }
 
-export function logout(userId: string): Promise<void> {
-	return http(`/api/auth/logout/${userId}`, {
+export function logout(accessToken: string): Promise<void> {
+	return http("/api/auth/logout", {
 		method: "POST",
+		headers: { Authorization: `Bearer ${accessToken}` },
 	});
 }

--- a/frontend/src/mocks/profile.ts
+++ b/frontend/src/mocks/profile.ts
@@ -5,7 +5,7 @@ export const MOCK_PROFILE: UserProfile = {
 	fullName: "Vinicius Brait Lorimier",
 	email: "vinicius@email.com",
 	avatarInitials: "VB",
-	role: "patient",
+	role: "Patient",
 	gender: "male",
 	ageYears: 22,
 	heightCm: 175,

--- a/frontend/src/types/profile.ts
+++ b/frontend/src/types/profile.ts
@@ -20,7 +20,7 @@ export interface UserProfile {
 	fullName: string;
 	email: string;
 	avatarInitials: string;
-	role: "patient" | "nutritionist";
+	role: "Patient" | "Nutritionist" | "Admin";
 	gender: Gender;
 	ageYears: number;
 	heightCm: number;

--- a/frontend/src/utils/errorTranslation.ts
+++ b/frontend/src/utils/errorTranslation.ts
@@ -1,22 +1,18 @@
 const errorDictionary: Record<string, string> = {
-  "Email is required.": "O e-mail é obrigatório.",
-  "Invalid email format.": "Formato de e-mail inválido.",
-  "Password is required.": "A senha é obrigatória.",
-  "Password must be at least 8 characters.": "A senha deve ter pelo menos 8 caracteres.",
-  "Password must contain at least one uppercase letter.": "A senha deve conter pelo menos uma letra maiúscula.",
-  "Password must contain at least one lowercase letter.": "A senha deve conter pelo menos uma letra minúscula.",
-  "Password must contain at least one number.": "A senha deve conter pelo menos um número.",
-  "Email already registered.": "Este e-mail já está cadastrado.",
-  "Name is required.": "O nome é obrigatório.",
-  "Name must be between 2 and 100 characters.": "O nome deve ter entre 2 e 100 caracteres.",
-  "Invalid credentials.": "E-mail ou senha incorretos.",
-  "Invalid email or password.": "E-mail ou senha incorretos.",
+  NAME_REQUIRED: "O nome é obrigatório.",
+  NAME_INVALID_LENGTH: "O nome deve ter entre 2 e 100 caracteres.",
+  EMAIL_REQUIRED: "O e-mail é obrigatório.",
+  EMAIL_INVALID_FORMAT: "Formato de e-mail inválido.",
+  PASSWORD_REQUIRED: "A senha é obrigatória.",
+  PASSWORD_TOO_SHORT: "A senha deve ter pelo menos 8 caracteres.",
+  PASSWORD_MISSING_UPPERCASE: "A senha deve conter pelo menos uma letra maiúscula.",
+  PASSWORD_MISSING_LOWERCASE: "A senha deve conter pelo menos uma letra minúscula.",
+  PASSWORD_MISSING_NUMBER: "A senha deve conter pelo menos um número.",
+  ROLE_INVALID: "Perfil inválido.",
+  EMAIL_ALREADY_REGISTERED: "Este e-mail já está cadastrado.",
+  INVALID_CREDENTIALS: "E-mail ou senha incorretos.",
 };
 
-export function translateError(errorMsg: string): string {
-  if (errorDictionary[errorMsg]) {
-    return errorDictionary[errorMsg];
-  }
-  
-  return errorMsg;
+export function translateError(code: string): string {
+  return errorDictionary[code] ?? "Ocorreu um erro inesperado. Tente novamente.";
 }


### PR DESCRIPTION
This pull request introduces several improvements to the NutriHub authentication API, focusing on standardizing error handling, improving validation, and enhancing the registration and login flows. The most important changes include the introduction of centralized error codes, updating validation logic to use these codes, returning access and refresh tokens upon registration, and updating tests to reflect these changes.

**Error Handling and Validation**

* Introduced a centralized `ErrorCodes` class in `ErrorCodes.cs` to standardize error messages across the API, replacing hardcoded strings in validators and use cases.
* Updated all validators (`AuthRequestValidator`, `LoginRequestValidator`) to use error codes from `ErrorCodes` for consistency and maintainability. [[1]](diffhunk://#diff-2313e536c0fa935e11424d6ba8b8c22fa3498d4d06fab58790d82a83aa73b8caL11-R27) [[2]](diffhunk://#diff-5ca986918cbae63843884798f57bacf486161a057c641dec73d58cdd7a0e7dfbL11-R16)
* Updated use cases (`RegisterUseCase`, `LoginUseCase`) to return error codes instead of strings in error responses. [[1]](diffhunk://#diff-8ae27efdb873b4345f18f579f1a981dfb589c41a84995e7a27acf53cd2f2b3e7L46-R47) [[2]](diffhunk://#diff-95b8b7b9035f02400eedfe3a7ba21bce485414d581d61b9d91350da760faa1c3L37-R67)

**Authentication Flow Enhancements**

* Modified the registration process to generate and return both access and refresh tokens, and to save the refresh token in the repository. The `AuthResponse` model now includes `AccessToken`, `RefreshToken`, and `Name` fields. [[1]](diffhunk://#diff-95b8b7b9035f02400eedfe3a7ba21bce485414d581d61b9d91350da760faa1c3L37-R67) [[2]](diffhunk://#diff-2e858ac733df3d9d83381723d55d2a1c147d3d5a528d30c0d785eed0db609e58R8-R11)

**Serialization and API Behavior**

* Configured controllers to serialize enums as strings using `JsonStringEnumConverter`, ensuring consistent enum representation in JSON responses.
* Removed the explicit enum converter attribute from `AuthRequest` since the global converter now handles this.

**Testing Updates**

* Updated all relevant tests to expect error codes instead of string messages, and to verify the presence of access and refresh tokens in registration responses. [[1]](diffhunk://#diff-0db308d08fc7cc68ba65ad1bd3915427699dabfb8fc576fdc61278214a4c92f3L34-R50) [[2]](diffhunk://#diff-0db308d08fc7cc68ba65ad1bd3915427699dabfb8fc576fdc61278214a4c92f3R79-R80) [[3]](diffhunk://#diff-1fcc79da780d2443bf77cd55e2c1d850d33d615bb74bdc3891b4405e65c23947L38-R39) [[4]](diffhunk://#diff-1fcc79da780d2443bf77cd55e2c1d850d33d615bb74bdc3891b4405e65c23947L49-R50) [[5]](diffhunk://#diff-1fcc79da780d2443bf77cd55e2c1d850d33d615bb74bdc3891b4405e65c23947L60-R61) [[6]](diffhunk://#diff-1fcc79da780d2443bf77cd55e2c1d850d33d615bb74bdc3891b4405e65c23947L73-R74) [[7]](diffhunk://#diff-1fcc79da780d2443bf77cd55e2c1d850d33d615bb74bdc3891b4405e65c23947L88-R89) [[8]](diffhunk://#diff-f3bd4590c9ef50c4fb667a27a2a72042c58501c3f80b9b058357d67218d11a86L28-R29)

These changes collectively improve the maintainability, reliability, and security of the authentication API.